### PR TITLE
Bech32bis and seed encoding

### DIFF
--- a/src/segwit_addr.h
+++ b/src/segwit_addr.h
@@ -24,6 +24,11 @@
 
 #include <stdint.h>
 
+typedef enum bech32_version_t {
+    version_bech32,
+    version_bech32_bis
+} bech32_version;
+
 /** Encode a SegWit address
  *
  *  Out: output:   Pointer to a buffer of size 73 + strlen(hrp) that will be
@@ -33,6 +38,7 @@
  *       ver:      Version of the witness program (between 0 and 16 inclusive).
  *       prog:     Data bytes for the witness program (between 2 and 40 bytes).
  *       prog_len: Number of data bytes in prog.
+ *       version:  The version of the Bech32 algorithm to use.
  *  Returns 1 if successful.
  */
 int segwit_addr_encode(
@@ -40,7 +46,8 @@ int segwit_addr_encode(
     const char *hrp,
     int ver,
     const uint8_t *prog,
-    size_t prog_len
+    size_t prog_len,
+    bech32_version version
 );
 
 /** Decode a SegWit address
@@ -61,7 +68,8 @@ int segwit_addr_decode(
     uint8_t* prog,
     size_t* prog_len,
     const char* hrp,
-    const char* addr
+    const char* addr,
+    bech32_version version
 );
 
 /** Encode a Bech32 string
@@ -77,7 +85,8 @@ int bech32_encode(
     char *output,
     const char *hrp,
     const uint8_t *data,
-    size_t data_len
+    size_t data_len,
+    bech32_version version
 );
 
 /** Decode a Bech32 string
@@ -95,7 +104,8 @@ int bech32_decode(
     char *hrp,
     uint8_t *data,
     size_t *data_len,
-    const char *input
+    const char *input,
+    bech32_version version
 );
 
 /** Encode an arbitrary seed in Bech32 format
@@ -107,7 +117,11 @@ int bech32_decode(
  *
  * Returns 1 if successful.
  */
-int bech32_seed_encode(char* output, const uint8_t *seed, size_t seed_len);
+int bech32_seed_encode(
+    char* output, 
+    const uint8_t *seed, 
+    size_t seed_len
+);
 
 /** Decode a Bech32 seed
  * Out: seed:     Pointer to a buffer of size 64 that will be updated to 
@@ -117,6 +131,10 @@ int bech32_seed_encode(char* output, const uint8_t *seed, size_t seed_len);
  * 
  * Returns 1 if successful.
  */
-int bech32_seed_decode(uint8_t* seed, size_t* seed_len, const char* input);
+int bech32_seed_decode(
+    uint8_t* seed, 
+    size_t* seed_len, 
+    const char* input
+);
 
 #endif

--- a/src/segwit_addr.h
+++ b/src/segwit_addr.h
@@ -98,4 +98,25 @@ int bech32_decode(
     const char *input
 );
 
+/** Encode an arbitrary seed in Bech32 format
+ * 
+ *  Out: output:  Pointer to a buffer of size strlen("seed") + data_len + 8 that
+ *                will be updated to contain the null-terminated Bech32 string.
+ *  In: seed:     Pointer to the seed.
+ *      seed_len: Length of the seed, in [1-64].
+ *
+ * Returns 1 if successful.
+ */
+int bech32_seed_encode(char* output, const uint8_t *seed, size_t seed_len);
+
+/** Decode a Bech32 seed
+ * Out: seed:     Pointer to a buffer of size 64 that will be updated to 
+ *                contain the see.
+ *      seed_len: Pointer to number of bytes in seed.
+ * In: input:     Pointer to the null-terminated Bech32 seed string.
+ * 
+ * Returns 1 if successful.
+ */
+int bech32_seed_decode(uint8_t* seed, size_t* seed_len, const char* input);
+
 #endif

--- a/test/test.c
+++ b/test/test.c
@@ -125,7 +125,7 @@ struct valid_seed_data {
 
 static struct valid_seed_data valid_seed[] = {
     {
-        "seed1chl9xyj538m0tsjglhpnf4a6nfdphnn9nc4w4ulq5gfv8eppvftl6ew3wez55hean67urzgq95tyrval5q3wal8h9acdjr6lwc7rrwqa07zt8",
+        "seed1chl9xyj538m0tsjglhpnf4a6nfdphnn9nc4w4ulq5gfv8eppvftl6ew3wez55hean67urzgq95tyrval5q3wal8h9acdjr6lwc7rrwqzspa5e",
         64,
         {
             0xc5, 0xfe, 0x53, 0x12, 0x54, 0x89, 0xf6, 0xf5,
@@ -171,12 +171,12 @@ int main(void) {
         char hrp[84];
         size_t data_len;
         int ok = 1;
-        if (!bech32_decode(hrp, data, &data_len, valid_checksum[i])) {
+        if (!bech32_decode(hrp, data, &data_len, valid_checksum[i], version_bech32)) {
             printf("bech32_decode fails: '%s'\n", valid_checksum[i]);
             ok = 0;
         }
         if (ok) {
-            if (!bech32_encode(rebuild, hrp, data, data_len)) {
+            if (!bech32_encode(rebuild, hrp, data, data_len, version_bech32)) {
                 printf("bech32_encode fails: '%s'\n", valid_checksum[i]);
                 ok = 0;
             }
@@ -192,7 +192,7 @@ int main(void) {
         char hrp[84];
         size_t data_len;
         int ok = 1;
-        if (bech32_decode(hrp, data, &data_len, invalid_checksum[i])) {
+        if (bech32_decode(hrp, data, &data_len, invalid_checksum[i], version_bech32)) {
             printf("bech32_decode succeeds on invalid string: '%s'\n", invalid_checksum[i]);
             ok = 0;
         }
@@ -207,10 +207,10 @@ int main(void) {
         uint8_t scriptpubkey[42];
         size_t scriptpubkey_len;
         char rebuild[93];
-        int ret = segwit_addr_decode(&witver, witprog, &witprog_len, hrp, valid_address[i].address);
+        int ret = segwit_addr_decode(&witver, witprog, &witprog_len, hrp, valid_address[i].address, version_bech32);
         if (!ret) {
             hrp = "tb";
-            ret = segwit_addr_decode(&witver, witprog, &witprog_len, hrp, valid_address[i].address);
+            ret = segwit_addr_decode(&witver, witprog, &witprog_len, hrp, valid_address[i].address, version_bech32);
         }
         if (!ret) {
             printf("segwit_addr_decode fails: '%s'\n", valid_address[i].address);
@@ -221,7 +221,7 @@ int main(void) {
             printf("segwit_addr_decode produces wrong result: '%s'\n", valid_address[i].address);
             ok = 0;
         }
-        if (ok && !segwit_addr_encode(rebuild, hrp, witver, witprog, witprog_len)) {
+        if (ok && !segwit_addr_encode(rebuild, hrp, witver, witprog, witprog_len, version_bech32)) {
             printf("segwit_addr_encode fails: '%s'\n", valid_address[i].address);
             ok = 0;
         }
@@ -236,11 +236,11 @@ int main(void) {
         size_t witprog_len;
         int witver;
         int ok = 1;
-        if (segwit_addr_decode(&witver, witprog, &witprog_len, "bc", invalid_address[i])) {
+        if (segwit_addr_decode(&witver, witprog, &witprog_len, "bc", invalid_address[i], version_bech32)) {
             printf("segwit_addr_decode succeeds on invalid address '%s'\n", invalid_address[i]);
             ok = 0;
         }
-        if (segwit_addr_decode(&witver, witprog, &witprog_len, "tb", invalid_address[i])) {
+        if (segwit_addr_decode(&witver, witprog, &witprog_len, "tb", invalid_address[i], version_bech32)) {
             printf("segwit_addr_decode succeeds on invalid address '%s'\n", invalid_address[i]);
             ok = 0;
         }
@@ -249,7 +249,7 @@ int main(void) {
     for (i = 0; i < sizeof(invalid_address_enc) / sizeof(invalid_address_enc[0]); ++i) {
         char rebuild[93];
         static const uint8_t program[42] = {0};
-        if (segwit_addr_encode(rebuild, invalid_address_enc[i].hrp, invalid_address_enc[i].version, program, invalid_address_enc[i].program_length)) {
+        if (segwit_addr_encode(rebuild, invalid_address_enc[i].hrp, invalid_address_enc[i].version, program, invalid_address_enc[i].program_length, version_bech32)) {
             printf("segwit_addr_encode succeeds on invalid input '%s'\n", rebuild);
             ++fail;
         }


### PR DESCRIPTION
-----BEGIN PGP SIGNED MESSAGE-----
Hash: SHA512

Added support for Bech32bis. Made seed encoding always use Bech32bis.	f2c30f9	Wolf McNally <wolf@wolfmcnally.com>	Apr 21, 2020 at 9:49 PM
Added ability to encode cryptographic seeds wrapped in bech32.	ace05b2	Wolf McNally <wolf@wolfmcnally.com>	Apr 21, 2020 at 8:59 PM
-----BEGIN PGP SIGNATURE-----
Comment: GPGTools - https://gpgtools.org

iQIzBAEBCgAdFiEElDZS7jhEF2DD3DU2S2wvz4lHgK4FAl6f2k4ACgkQS2wvz4lH
gK6tNQ//SFlUBgvsC7gFqp4zfc43QRVa38MD6tpFV++NRVkJho+KwToMJ+uDlmcj
0sEiGcEXh8SYtEMMtZvtM3ERCoYC7ETDR5/34F3YTrHziZ0ytxX9aCStg0nCDgES
b0gOFWKMuABJgoDoBqjYTufdFpUSdmwOmelndCLVzIyfaLgCpNWyXgjaRdXhNoUT
pNH6URFBFmlSIdDjBpdiRyGTN0HQNcaf9pwBo0Fl257bb9mBv8Gmf+Ki6CEIwRy5
Ay7KWfVwQRnnG7LHVZj+8CHFVjFTIXOnKyO7RV0pEfBAd/jY1Qw6ijO3TDqDGMw8
mBbM0CQhsBIbuM/epnLmaF9PPF15nmXGTIgddoQN6tNNygLsZPc7h3BH/pz2BL73
OTjpDTBrtxqsU9wUNmoU4Mdf32NYOiIc0uBIim0Ep/GZx35SfqhYHRKFJmjLx0+Y
S5+krmX0RFt3rHooX8l8ATr6zhhyqUkH4YbFk7rkiZsqQF8LmDuXgzFushn/WkUf
Oz9PmicwUHd2Lxk/5GFe4kdZIoXVlU942CVyOlZ4/k2oCXhkaHZv9nP0wf6O/nWM
4jA/mdyaVtOtuH4pNujULlOVGhS4F3p9yEE91Tcv9Ec40NVlypqG4mxZPsoaczHN
pUtlqQSfcqKjiwI5E63PjG8iQ5yqHW/SvpTlEsrLxGUs/4pizkY=
=qwo9
-----END PGP SIGNATURE-----
